### PR TITLE
fix: disable dependency review for repositories without GitHub Advanc…

### DIFF
--- a/.github/CICD_SETUP.md
+++ b/.github/CICD_SETUP.md
@@ -39,14 +39,13 @@ Set up branch protection for `main` branch:
 1. Go to Repository Settings → Branches
 2. Add rule for `main` branch:
    - Require pull request reviews before merging
-   - Require status checks to pass before merging
-   - Required status checks:
+   - Require status checks to pass before merging   - Required status checks:
      - `lint-and-test (16.x)`
      - `lint-and-test (18.x)`
      - `lint-and-test (20.x)`
      - `version-check`
      - `security-scan`
-     - `dependency-review`
+     ~~- `dependency-review`~~ (disabled - requires GitHub Advanced Security)
    - Require branches to be up to date before merging
    - Restrict pushes that create files that match `.github/workflows/*`
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -130,18 +130,19 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
-        sarif_file: snyk.sarif
-
-  dependency-review:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Dependency Review
-      uses: actions/dependency-review-action@v4
-      with:
-        fail-on-severity: moderate
-        allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC
+        sarif_file: snyk.sarif  # dependency-review:
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'pull_request'
+  #   
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v4
+  #   
+  #   - name: Dependency Review
+  #     uses: actions/dependency-review-action@v4
+  #     with:
+  #       fail-on-severity: moderate
+  #       allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC
+  #   
+  #   # NOTE: Dependency Review requires GitHub Advanced Security
+  #   # Enable this job if you have GitHub Advanced Security enabled

--- a/PIPELINE_SETUP.md
+++ b/PIPELINE_SETUP.md
@@ -21,11 +21,11 @@ Go to your GitHub repo → Settings → Branches → Add rule for `main`:
 - ✅ Require status checks to pass before merging
 - Required status checks:
   - `lint-and-test (16.x)`
-  - `lint-and-test (18.x)` 
+  - `lint-and-test (18.x)`
   - `lint-and-test (20.x)`
   - `version-check`
   - `security-scan`
-  - `dependency-review`
+  ~~- `dependency-review`~~ (disabled - requires GitHub Advanced Security)
 - ✅ Require branches to be up to date before merging
 
 ### 2. Get VS Code Marketplace Token

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm run package
 - **WindowTitleService**: Core service handling title composition and updates
 - **Git Integration**: Uses VS Code's Git API with `.git/HEAD` fallback
 - **Event-Driven**: Listens to workspace and editor changes
-- **Configuration-Aware**: Respects user preferences and custom patterns
+- **Configuration-Aware**: Respects most user preferences and custom patterns
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
…ed Security

- Comment out dependency-review job in pr-checks.yml
- Update documentation to reflect the change
- This feature requires GitHub Advanced Security which is not available on free private repos

## Description

Brief description of what this PR does.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this manually in VS Code

## Version Update

- [ ] I have updated the version number in `package.json` following semantic versioning
- [ ] Version bump type: `patch` | `minor` | `major`

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Add any additional notes about the implementation, breaking changes, or anything reviewers should pay special attention to.
